### PR TITLE
Improve action logs

### DIFF
--- a/main.go
+++ b/main.go
@@ -51,7 +51,12 @@ func newRodeClient(logger *zap.Logger, conf *config.Config) (*grpc.ClientConn, r
 }
 
 func newLogger() (*zap.Logger, error) {
-	return zap.NewDevelopment()
+	c := zap.NewDevelopmentConfig()
+	c.DisableCaller = true
+	c.EncoderConfig.LevelKey = ""
+	c.EncoderConfig.TimeKey = ""
+
+	return c.Build()
 }
 
 func setOutputVariable(name string, value bool) {
@@ -87,7 +92,6 @@ func main() {
 	setOutputVariable("pass", pass)
 
 	if !pass && c.Enforce {
-		logger.Info("Policy evaluation failed")
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Trying to show more useful information than just a successful exit code. I think the next iteration would be to post the results summary on a PR (if triggered by the `pull_request` event). 

Examples:

<details>
<summary>evaluation failed</summary>

```shell
Taking policy id from config    {"policyId": "c2809832-98dd-479a-a6d5-e57767695da3"}
Evaluating policy       {"policyId": "c2809832-98dd-479a-a6d5-e57767695da3", "resource": "foo"}
Resource failed policy:
Harbor scanned image 0 times. Last completed at set()
Harbor scan found 0 low severity vulnerabilities (max: 10)
Harbor scan found 0 medium severity vulnerabilities (max: 10)
Harbor scan found 0 high severity vulnerabilities (max: 2)
```

</details>

<details>
<summary>successful evaluation</summary>

```shell
Taking policy id from config    {"policyId": "c2809832-98dd-479a-a6d5-e57767695da3"}
Evaluating policy       {"policyId": "c2809832-98dd-479a-a6d5-e57767695da3", "resource": "harbor.localhost/rode-demo/alpine@sha256:def822f9851ca422481ec6fee59a9966f12b351c62ccb9aca841526ffaa9f748"}
Resource passed policy:
Harbor scanned image 1 times. Last completed at {"2021-05-18T17:01:53Z"}
Harbor scan found 0 low severity vulnerabilities (max: 10)
Harbor scan found 0 medium severity vulnerabilities (max: 10)
Harbor scan found 0 high severity vulnerabilities (max: 2)
```

</details>